### PR TITLE
Closes #91 [Prevented the dashboard from displaying content when a us…

### DIFF
--- a/app/Http/Controllers/ConfigurationController.php
+++ b/app/Http/Controllers/ConfigurationController.php
@@ -126,7 +126,7 @@ class ConfigurationController extends Controller
         return redirect('configuration');
     }
 
-    private function getAllConfiguration($userId){
+    static function getAllConfiguration($userId){
         $configurations = Configuration::where('user_id', $userId)
                                         ->orderBy('id', 'desc')
                                         ->get();

--- a/app/Http/Controllers/SpentController.php
+++ b/app/Http/Controllers/SpentController.php
@@ -27,9 +27,10 @@ class SpentController extends Controller
     public function index(Request $request) {
         $percentageUsed = null;
         $message = false;
-
+        $hasConfiguration = true;
         $currentYear = now()->year;
         $user = Auth::user();
+        $config = ConfigurationController::getAllConfiguration($user->id);
     
         $selectedMonth = $request->input('period');
 
@@ -87,7 +88,10 @@ class SpentController extends Controller
             'rest_money' => $formattedRestMoney,
             'count_spent' => $countSpents,
         ];
-        
+
+        if($config->isEmpty()){
+            $hasConfiguration = false;
+        }
         return view('dashboard', [
             'spents' => $data['spents'],
             'user' => $user,
@@ -100,7 +104,8 @@ class SpentController extends Controller
             'percentageUsed' => $percentageUsed,
             'message' => $message,
             'branchName' => Helps::getGitBranchName(),
-            'footerInformation' => $footerInformation
+            'footerInformation' => $footerInformation,
+            'hasConfiguration' => $hasConfiguration
         ]);
     }
 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -30,6 +30,8 @@
                 </x-notification>
             @endif
             <main class="container mx-auto p-4 mb-14">
+            
+            @if($hasConfiguration)
                 <div class="w-11/12 mx-auto">
                     <div class="flex justify-between sm-500:mb-4">
                         <a href="{{ route('spents.create') }}" id="add-expense">
@@ -73,8 +75,8 @@
                             {{ $percentageUsed['percentageUser'] }}%
                         </div>
                     </div>
-                    
-                    <x-spent-card :spents="$spents"/>
+            @endif        
+                    <x-spent-card :spents="$spents"/> 
 
                     @if ($branchName != 'main')
                         <div class="fixed bottom-16 left-1/2 transform -translate-x-1/2 bg-white px-2 border border-gray-300 rounded shadow-lg cursor-not-allowed">


### PR DESCRIPTION
…er has no prior configuration records. This avoids confusion for new users by ensuring that only relevant information is shown once the initial setup is complete].